### PR TITLE
Updates test eslintrc to allow jsx and chai configuration

### DIFF
--- a/config/eslint/.eslintrc-react-test
+++ b/config/eslint/.eslintrc-react-test
@@ -1,3 +1,10 @@
 ---
 extends:
+  - "eslint-config-defaults/configurations/walmart/es6-react"
   - "eslint-config-defaults/configurations/walmart/es6-test"
+globals:
+  document: false
+  expect: false
+  it: false
+rules:
+  "no-unused-expressions": 0


### PR DESCRIPTION
`eslint` was failing for all of these valid things for `test`, so I added `react` extends (so we can use `jsx` without getting screamed at), `document`, `expect` and `it` (because they should always be used in tests) and turned off `no-unused-expressions` because that's how `expect` roles (it's always an unused expression).