### PR TITLE
Chore: add lib tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build-dist-min": "webpack --config node_modules/electrode-bolt/config/webpack/webpack.config.js --colors",
     "build-dist-dev": "webpack --config node_modules/electrode-bolt/config/webpack/webpack.config.dev.js --colors",
     "build-dist": "bolt clean-dist && bolt build-dist-min && bolt build-dist-dev",
+    "clean-lib": "rimraf lib",
+    "build-lib": "bolt clean-lib && babel --stage 0 src -d lib",
     "server-dev": "webpack-dev-server --config node_modules/electrode-bolt/config/webpack/webpack.config.demo.dev.js --colors",
     "server-hot": "webpack-dev-server --config node_modules/electrode-bolt/config/webpack/webpack.config.demo.hot.js --colors",
     "server-test": "webpack-dev-server --config node_modules/electrode-bolt/config/webpack/webpack.config.test.js --colors",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build-dist": "bolt clean-dist && bolt build-dist-min && bolt build-dist-dev",
     "clean-lib": "rimraf lib",
     "build-lib": "bolt clean-lib && babel --stage 0 src -d lib",
+    "clean": "bolt clean-lib && bolt clean-dist",
+    "build": "bolt build-lib && bolt build-dist",
     "server-dev": "webpack-dev-server --config node_modules/electrode-bolt/config/webpack/webpack.config.demo.dev.js --colors",
     "server-hot": "webpack-dev-server --config node_modules/electrode-bolt/config/webpack/webpack.config.demo.hot.js --colors",
     "server-test": "webpack-dev-server --config node_modules/electrode-bolt/config/webpack/webpack.config.test.js --colors",


### PR DESCRIPTION
Adds tasks to `build` and `clean` `lib` directory and tasks to run `build` and `clean` tasks for `lib` and `dist` at the same time.