### PR TITLE
Chore: eslint test

### DIFF
--- a/config/eslint/.eslintrc-react-test
+++ b/config/eslint/.eslintrc-react-test
@@ -5,6 +5,9 @@ extends:
 globals:
   document: false
   expect: false
-  it: false
+  it: false,
+  sinon: false
 rules:
   "no-unused-expressions": 0
+  "max-len": [2, 100, 2, {ignorePattern: "^\\s*(?:it|describe)\\(.*"}]
+  "max-statements": 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-bolt",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Opinionated meta config runner for react components",
   "scripts": {
     "testBolt": "echo 'bolt is working!'",


### PR DESCRIPTION
updates eslint for tests to not have a a max-length on `it` or `describe` lines and not have a `max-statements` inside of describe or it.