### PR TITLE
allow webpack dev server port to be specified

### DIFF
--- a/config/webpack/webpack.config.demo.dev.js
+++ b/config/webpack/webpack.config.demo.dev.js
@@ -10,6 +10,7 @@ var _ = require("lodash");
 module.exports = {
 
   devServer: {
+    port: process.env.WEBPACK_DEVSERVER_PORT,
     contentBase: path.join(process.cwd(), "demo"),
     noInfo: false
   },

--- a/config/webpack/webpack.config.demo.hot.js
+++ b/config/webpack/webpack.config.demo.hot.js
@@ -13,7 +13,7 @@ base.devServer.hot = true;
 module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {
     app: [
-      "webpack-dev-server/client?http://0.0.0.0:8080", // WebpackDevServer host and port
+      "webpack-dev-server/client?http://0.0.0.0:" + (process.env.WEBPACK_DEVSERVER_PORT || "8080"), // WebpackDevServer host and port
       "webpack/hot/only-dev-server",
       "./demo/demo.jsx"
     ]


### PR DESCRIPTION
I had a port conflict when running several `bolt` commands, related to the webpack dev server being hardcoded to `8080`, so this allows a port to be specified using an environment variable, `WEBPACK_DEVSERVER_PORT`