### PR TITLE
Fix: Allow private bolt-standard-configs

### DIFF
--- a/lib/bolt.js
+++ b/lib/bolt.js
@@ -48,7 +48,7 @@ function checkForBoltStandard() {
   var boltStandard;
 
   for (var dep in cwdPkg.devDependencies) {
-    if (dep.match(/^bolt-standard-.*/)) {
+    if (dep.match(/bolt-standard-.*/)) {
       boltStandard = dep;
       break;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-bolt",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Opinionated meta config runner for react components",
   "scripts": {
     "dev": "bolt server-dev & bolt server-test",


### PR DESCRIPTION
This fixes finding private dependencies for any `bolt-standard-*` configs.