### PR TITLE
Add gif to loader test for url loader

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
       test: /\.styl$/,
       loader: "style-loader!css-loader!stylus-loader"
     }, {
-      test: /\.(png|jpg|svg)$/,
+      test: /\.(png|jpg|svg|gif)$/,
       loader: "url-loader?limit=8192"
     }]
   },


### PR DESCRIPTION
Won't change the `limit` on the `url-loader`, as it is only there to decide whether to use an encoded `data-url` or to pass the file to the `file-loader`, which is probably the right limit for that.

Closes #37.